### PR TITLE
update bundler before travis ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-script: 'bundle exec rake'
 language: ruby
+before_install:
+  - gem update bundler
+script: 'bundle exec rake'
 os:
   - linux
   - osx


### PR DESCRIPTION
This addresses the old versions of bundler used on travis ci. Issue originally noticed in PR #77.