### PR TITLE
REPL command using pry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,18 +2,14 @@ source 'http://rubygems.org'
 gemspec
 
 group :development do
-  gem 'bundler', '~> 1.10'
+  gem 'byebug'
+  gem 'pry'
+  gem 'pry-byebug'
   gem 'rubocop'
 end
 
 group :test do
-  gem 'rantly',  '~> 0.3'
-end
-
-group :debug, optional: true do
-  gem 'pry'
-  gem 'byebug'
-  gem 'pry-byebug'
+  gem 'rantly', '~> 0.3'
 end
 # vim: ts=2 sw=2:
 # encoding: utf-8

--- a/scripts/05-repl.sh
+++ b/scripts/05-repl.sh
@@ -1,0 +1,12 @@
+#/usr/bin/env bash
+
+# The next three lines are for the go shell.
+export SCRIPT_NAME="repl"
+export SCRIPT_HELP="Run the REPL (read,eval,print,loop)"
+[[ "$GOGO_GOSH_SOURCE" -eq 1 ]] && return 0
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"/../
+source "$DIR"/env.sh || exit 1
+assert-env-or-die SCRIPTS
+"$SCRIPTS"/repl.sh
+

--- a/scripts/repl.sh
+++ b/scripts/repl.sh
@@ -1,0 +1,8 @@
+#/usr/bin/env bash
+# Normal script execution starts here.
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"/../
+source "$DIR"/env.sh || exit 1
+cd "$DIR" || exit 1
+
+pry -I "./lib" -r "bel"
+

--- a/scripts/repl.sh
+++ b/scripts/repl.sh
@@ -4,5 +4,14 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"/../
 source "$DIR"/env.sh || exit 1
 cd "$DIR" || exit 1
 
+echo "Compiling libbel C extension."
+COMPILE_OUT=$(mktemp)
+rake compile > /dev/null 2> $COMPILE_OUT
+if [ $? -ne 0 ]; then
+  echo "Compilation error, output of \"rake compile\":"
+  cat $COMPILE_OUT
+  exit 1
+fi
+
 pry -I "./lib" -r "bel"
 


### PR DESCRIPTION
Adds a REPL script using pry that loads and requires the current bel.rb tree. Hooked into go shell.

moves debug gem group into development so that it is always installed

removed bundler dependency since "optional: true" is no longer used