### PR TITLE
Fix missing namespace prefixes that occur when parsing IO in chunks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,5 @@ matrix:
     - os: osx
     - rvm: ruby-head
     - rvm: jruby-head
+    - rvm: rbx-3 # Seems to be trouble installing 3.14 on Travis CI.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ rvm:
   - 2.1.0
   - 2.2.0
   - 2.3.0
+  - jruby-9.0.5.0
   - rbx-2
+  - rbx-3
   - ruby-head
-  - jruby-9.0.4.0
   - jruby-head
 matrix:
   allow_failures:

--- a/.yardopts
+++ b/.yardopts
@@ -7,4 +7,5 @@
 --private
 "examples/**/*.rb"
 "lib/**/*.rb"
+"spec/**/*.rb"
 "test/**/*.rb"

--- a/lib/bel/language.rb
+++ b/lib/bel/language.rb
@@ -26,7 +26,13 @@ module BEL
       end
 
       def to_bel
-        %Q{SET DOCUMENT #{self.name} = #{ensure_quotes(self.value)}}
+        property_value =
+          if self.value.respond_to?(:each)
+            self.value.map(&:to_s).join('|')
+          else
+            self.value.to_s
+          end
+        %Q{SET DOCUMENT #{self.name} = #{ensure_quotes(property_value)}}
       end
       alias_method :to_s, :to_bel
     end
@@ -38,7 +44,7 @@ module BEL
           %Q{DEFINE ANNOTATION #{self.prefix} AS LIST {#{self.value.join(',')}}}
         when :pattern
           %Q{DEFINE ANNOTATION #{self.prefix} AS PATTERN "#{self.value}"}
-        when :url
+        when :uri, :url
           %Q{DEFINE ANNOTATION #{self.prefix} AS URL "#{self.value}"}
         end
       end

--- a/lib/bel/ragel/common.rl
+++ b/lib/bel/ragel/common.rl
@@ -119,27 +119,5 @@ machine bel;
     (FUNCTION | STRING NL)+;
 }%%
 =end
-
-if __FILE__ == $0
-  require_relative 'language'
-
-  class Parser
-
-    def initialize
-      @items = []
-      %% write data;
-    end
-
-    def exec(input)
-      buffer = []
-      stack = []
-      data = input.read.unpack('C*')
-
-      %% write init;
-      %% write exec;
-    end
-  end
-  Parser.new.exec(ARGV[0] ? File.open(ARGV[0], 'r:UTF-8') : $stdin)
-end
 # vim: ts=2 sw=2:
 # encoding: utf-8

--- a/lib/bel/ragel/define.rl
+++ b/lib/bel/ragel/define.rl
@@ -115,26 +115,5 @@ module BEL
     end
   end
 end
-
-# intended for direct testing
-if __FILE__ == $0
-  require 'bel'
-
-  if ARGV[0]
-    content = (File.exists? ARGV[0]) ? File.open(ARGV[0], 'r:UTF-8').read : ARGV[0]
-  else
-    content = $stdin.read
-  end
-
-  class DefaultObserver
-    def update(obj)
-      puts obj
-    end
-  end
-
-  parser = BEL::Script::Parser.new
-  parser.add_observer(DefaultObserver.new)
-  parser.parse(content) 
-end
 # vim: ts=2 sw=2:
 # encoding: utf-8

--- a/lib/bel/ragel/set.rl
+++ b/lib/bel/ragel/set.rl
@@ -120,26 +120,5 @@ module BEL
     end
   end
 end
-
-# intended for direct testing
-if __FILE__ == $0
-  require 'bel'
-
-  if ARGV[0]
-    content = (File.exists? ARGV[0]) ? File.open(ARGV[0], 'r:UTF-8').read : ARGV[0]
-  else
-    content = $stdin.read
-  end
-
-  class DefaultObserver
-    def update(obj)
-      puts obj
-    end
-  end
-
-  parser = BEL::Script::Parser.new
-  parser.add_observer(DefaultObserver.new)
-  parser.parse(content) 
-end
 # vim: ts=2 sw=2:
 # encoding: utf-8

--- a/lib/bel/ragel/statement.rl
+++ b/lib/bel/ragel/statement.rl
@@ -55,10 +55,10 @@
     rel = @relbuffer.pack('C*').force_encoding('utf-8')
     @statement_stack.last.relationship = rel.to_sym
   }
-  action cmts {cmtbuffer = []}
-  action cmtn {cmtbuffer << fc}
+  action cmts {@cmtbuffer = []}
+  action cmtn {@cmtbuffer << fc}
   action cmte {
-    comment = cmtbuffer.pack('C*').force_encoding('utf-8')
+    comment = @cmtbuffer.pack('C*').force_encoding('utf-8')
     @statement_stack.first.comment = comment
   }
 
@@ -133,27 +133,6 @@ module BEL
       end
     end
   end
-end
-
-# intended for direct testing
-if __FILE__ == $0
-  require 'bel'
-
-  if ARGV[0]
-    content = (File.exists? ARGV[0]) ? File.open(ARGV[0], 'r:UTF-8').read : ARGV[0]
-  else
-    content = $stdin.read
-  end
-
-  class DefaultObserver
-    def update(obj)
-      puts obj
-    end
-  end
-
-  parser = BEL::Script::Parser.new
-  parser.add_observer(DefaultObserver.new)
-  parser.parse(content) 
 end
 # vim: ts=2 sw=2:
 # encoding: utf-8

--- a/lib/bel/ragel/term.rl
+++ b/lib/bel/ragel/term.rl
@@ -12,7 +12,7 @@ machine bel;
   action term_fx {
     fx = @name.to_sym
     @term_stack.push(BEL::Model::Term.new(fx, []))
-    pfx = nil
+    @pfx = nil
     @pbuf = []
   }
   action term_arg {
@@ -23,8 +23,8 @@ machine bel;
       end
 
       ns =
-			  if pfx
-				  @namespaces[pfx.to_sym] ||= BEL::Namespace::NamespaceDefinition.new(pfx, nil, nil)
+			  if @pfx
+				  @namespaces[@pfx.to_sym] ||= BEL::Namespace::NamespaceDefinition.new(@pfx, nil, nil)
 			  else
 				  nil
 			  end
@@ -35,7 +35,7 @@ machine bel;
       yield param
     end
     @pbuf = []
-    pfx = nil
+    @pfx = nil
   }
   action term_pop {
     @term = @term_stack.pop
@@ -45,7 +45,7 @@ machine bel;
   }
   action pbuf  { @pbuf << fc }
   action pns {
-    pfx = @pbuf.map(&:chr).join()
+    @pfx = @pbuf.map(&:chr).join()
     @pbuf = []
   }
 
@@ -119,27 +119,6 @@ module BEL
       end
     end
   end
-end
-
-# intended for direct testing
-if __FILE__ == $0
-  require 'bel'
-
-  if ARGV[0]
-    content = (File.exists? ARGV[0]) ? File.open(ARGV[0], 'r:UTF-8').read : ARGV[0]
-  else
-    content = $stdin.read
-  end
-
-  class DefaultObserver
-    def update(obj)
-      puts obj
-    end
-  end
-
-  parser = BEL::Script::Parser.new
-  parser.add_observer(DefaultObserver.new)
-  parser.parse(content) 
 end
 # vim: ts=2 sw=2:
 # encoding: utf-8

--- a/lib/bel/translator/plugins/bel_script/bel_yielder.rb
+++ b/lib/bel/translator/plugins/bel_script/bel_yielder.rb
@@ -51,7 +51,7 @@ module BEL::Translator::Plugins
           end
 
         self_eigenclass = (class << self; self; end)
-        self_eigenclass.include(serialization_module)
+        self_eigenclass.send(:include, serialization_module)
       end
 
       def each

--- a/spec/unit/parse_chunk_spec.rb
+++ b/spec/unit/parse_chunk_spec.rb
@@ -1,0 +1,35 @@
+require 'bel'
+require 'rantly'
+require 'rantly/rspec_extensions'
+
+# Tests property that parsing BEL Script records, with varying IO chunk sizes,
+# are equivalent to parsing data fully read/buffered:
+#
+# @sanea observed the loss of namespace prefix occurred between parsed chunks.
+# This was happening because the namespace prefix was a local variable which
+# was reinitialized on the next IO chunk. Changing "pfx" to an instance
+# variable fixed this behavior. This property test checks this behavior holds.
+#
+# @see https://github.com/OpenBEL/bel.rb/issues/71
+describe BEL::Script, "#parse" do
+
+  context 'when parsing IO with variable chunk size' do
+
+    it 'BEL statement parsing is consistent for all chunk sizes' do
+      # Parse buffered string for comparison.
+      bel_statement    = 'path(SDIS:"tissue damage") -> bp(GOBP:"cell proliferation")'
+      buffered_results = BEL::Script.parse(bel_statement).each.to_a
+
+      # Check that parsed IO is equal to buffered result for varying
+      # chunk sizes.
+      property_of {
+        range(1, bel_statement.size)
+      }.check(1000) { |chunk_size|
+        io         = StringIO.new(bel_statement)
+        io_results = BEL::Script.parse_chunked(io, {}, chunk_size).each.to_a
+        expect(io_results).to eql(buffered_results)
+      }
+    end
+  end
+end
+# vim: ts=2 sw=2:


### PR DESCRIPTION
Thanks to @sanea for the debugging. He discovered that the namespace prefixes are lost when they occur between IO chunks.

This PR addresses the issue and provides the regenerated ragel parser.

@sanea Please take a look.