### PR TITLE
Update quoting.rb

### DIFF
--- a/lib/bel/quoting.rb
+++ b/lib/bel/quoting.rb
@@ -5,12 +5,10 @@ module BEL
     KeywordMatcher = Regexp.compile(/^(SET|DEFINE|a|g|p|r|m)$/)
 
     def ensure_quotes identifier
-      return "" unless identifier
-      identifier.to_s.gsub! '"', '\"'
       if quotes_required? identifier
         %Q{"#{identifier}"}
       else
-        identifier
+        identifier.to_s
       end
     end
 


### PR DESCRIPTION
This change addresses issue #104.

The issue is caused by this line of code
> identifier.to_s.gsub! '"', '\"'

which triggers a cascade of substitution. I fix this by removing the `:to_s` and `:gsub!` since interpolating `identifier` internally calls the `:to_s` method which automatically escapes _quotes_ as required. That being the case, the entire line of code can be removed in favour of the interpolation and explicit call of `:to_s` within the `if-else` statement that follows.

This implementation passes all the `quoting_spec`.